### PR TITLE
Add FLAG_ACTIVITY_NEW_TASK for wallet intent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+.DS_Store
+

--- a/walletconnectkit/src/main/java/dev/pinkroom/walletconnectkit/data/wallet/WalletRepository.kt
+++ b/walletconnectkit/src/main/java/dev/pinkroom/walletconnectkit/data/wallet/WalletRepository.kt
@@ -21,12 +21,14 @@ internal class WalletRepository(
     override fun openWallet() {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.data = Uri.parse("wc:")
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         walletConnectKitConfig.context.startActivity(intent)
     }
 
     override fun requestHandshake() {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.data = Uri.parse(sessionRepository.wcUri)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         walletConnectKitConfig.context.startActivity(intent)
     }
 


### PR DESCRIPTION
Good morning,

I've been using your awesome lib to integrate it in a service which only has an `ApplicationContext` provided by Hilt. As this service will be used by a JetpackCompose app, I couldn't use the button provided by `walletconnectkit`. This small change was the only thing that prevented me to use the library, as android would not allow starting an activity outside of an activity context without `FLAG_ACTIVITY_NEW_TASK` being specified.