### PR TITLE
Remove runCatching call

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ is a `suspend` function so, you need to call it inside a `coroutine`.
 
 ````kotlin
 lifecycleScope.launch {
-    runCatching { walletConnectKit.performTransaction(toAddress, value) }
+    walletConnectKit.performTransaction(toAddress, value)
         .onSuccess { /* Handle onSuccess */ }
         .onFailure { /* Handle onFailure */ }
 }

--- a/sample/src/main/java/dev/pinkroom/sample/walletconnectkit/MainActivity.kt
+++ b/sample/src/main/java/dev/pinkroom/sample/walletconnectkit/MainActivity.kt
@@ -75,7 +75,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
             val toAddress = toAddressView.text.toString()
             val value = valueView.text.toString()
             lifecycleScope.launch {
-                runCatching { walletConnectKit.performTransaction(toAddress, value) }
+                walletConnectKit.performTransaction(toAddress, value)
                     .onSuccess { showMessage("Transaction done!") }
                     .onFailure { showMessage(it.message ?: it.toString()) }
             }

--- a/walletconnectkit/src/main/java/dev/pinkroom/walletconnectkit/data/wallet/WalletManager.kt
+++ b/walletconnectkit/src/main/java/dev/pinkroom/walletconnectkit/data/wallet/WalletManager.kt
@@ -13,7 +13,7 @@ interface WalletManager {
         nonce: String? = null,
         gasPrice: String? = null,
         gasLimit: String? = null,
-    ): Session.MethodCall.Response
+    ): Result<Session.MethodCall.Response>
 
     suspend fun performTransaction(
         address: String,
@@ -21,5 +21,5 @@ interface WalletManager {
         nonce: String? = null,
         gasPrice: String? = null,
         gasLimit: String? = null,
-    ): Session.MethodCall.Response
+    ): Result<Session.MethodCall.Response>
 }


### PR DESCRIPTION
Currently, we need to call the `performTransaction` function inside a `runCatching` or try/catch block. This PR removes that need by returning the exception inside a result.